### PR TITLE
fix: safari用のcssハックを削除

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -108,7 +108,6 @@ a {
 
 .Counter {
   /* font-size: 24px; */
-  line-height: 0; /* 仮 */
   margin: auto;
   display: flex;
   align-items: center;
@@ -117,11 +116,9 @@ a {
 
 .Counter > p {
   font-size: 24px;
-  padding: 1em;
-  width: 2ch;
+  width: 3ch;
   text-align:center;
   position:relative;
-  margin: 2vh 0px;
 }
 .Build img {
   margin: auto;
@@ -134,20 +131,4 @@ a {
   height: 32px;
   background: #ccc;
   border-radius: 50%;
-}
-
-/* Safariフォント崩れ対応（修正中） */
-/* https://teratail.com/questions/78551 */
-*,
-*::before,
-*::after{
-    font-weight: normal;
-    line-height: 1em;
-    padding:0;
-    margin: 0;
-    box-sizing: border-box;
-    -webkit-tap-highlight-color:rgba(0,0,0,0);
-    -webkit-user-select: none;
-backface-visibility:hidden;
--webkit-backface-visibility:hidden;
 }


### PR DESCRIPTION
`line-height: 0` をやめることでsafari用のcssハックを削除できそうです。

このcssハックは `.Counter > p` の中のフォントが崩れた感じで描画される問題を回避するために入れているのかなと思いますが、Safariでは高さ0の要素の場合おそらくですが高速化を目的としたレンダリングの省略をしていて、それが原因で崩れた感じに見えていたんだと思っています。

`line-height: 0` を消すことで見た目が変わってしまうので、それ以外のstyleもちょっとだけ調整してみました。